### PR TITLE
Visualizer in Thread

### DIFF
--- a/object-reconstruction/CMakeLists.txt
+++ b/object-reconstruction/CMakeLists.txt
@@ -17,9 +17,9 @@ include_directories(${objects3D_INCLUDE_DIRS})
 include_directories(${minimumBoundingBox_INCLUDE_DIRS})
 
 #file(GLOB source src/*.cpp)
-set(source src/main.cpp src/objectReconstr.cpp src/reconstructionRoutine.cpp)
+set(source src/main.cpp src/objectReconstr.cpp src/reconstructionRoutine.cpp src/visThread.cpp)
 #file(GLOB header include/*.h)
-set(header include/objectReconstr.h include/reconstructionRoutine.h)
+set(header include/objectReconstr.h include/reconstructionRoutine.h include/visThread.h)
 
 link_directories(${PCL_LIBRARY_DIRS})
 add_definitions(${PCL_DEFINITIONS})
@@ -27,3 +27,5 @@ add_definitions(${PCL_DEFINITIONS})
 add_executable(${PROJECTNAME} ${source} ${header})
 target_link_libraries(${PROJECTNAME} ${YARP_LIBRARIES} stereoVision objects3D minimumBoundingBox icubmod ${OpenCV_LIBRARIES} ${PCL_LIBRARIES})
 install(TARGETS ${PROJECTNAME} DESTINATION bin)
+
+yarp_install(FILES ${PROJECTNAME}.xml DESTINATION ${ICUBCONTRIB_MODULES_INSTALL_DIR})

--- a/object-reconstruction/app/conf/config.ini
+++ b/object-reconstruction/app/conf/config.ini
@@ -1,3 +1,3 @@
 name object-reconstruction
 robot icub
-computeBB on
+computeBB false

--- a/object-reconstruction/include/objectReconstr.h
+++ b/object-reconstruction/include/objectReconstr.h
@@ -23,6 +23,7 @@
 #include <iCub/data3D/SurfaceMeshWithBoundingBox.h>
 #include <iCub/data3D/minBoundBox.h>
 #include <reconstructionRoutine.h>
+#include <visThread.h>
 
 #define ACK                     VOCAB3('a','c','k')
 #define NACK                    VOCAB4('n','a','c','k')
@@ -53,8 +54,9 @@ class ObjectReconstr: public yarp::os::RFModule
     yarp::os::RpcClient segmentationPort;
 
     ReconstructionRoutine recRoutine;
+    VisThread *visThrd;
 
-    void visualize(boost::shared_ptr<pcl::visualization::PCLVisualizer> tmpViewer, pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr cloud);
+    //void visualize(boost::shared_ptr<pcl::visualization::PCLVisualizer> tmpViewer, pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr cloud);
     bool updateCloud();
 	void filter(pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud_in,pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud_in_filtered, bool second=false);
     yarp::os::Bottle getPixelList();

--- a/object-reconstruction/include/visThread.h
+++ b/object-reconstruction/include/visThread.h
@@ -1,0 +1,127 @@
+/*
+ * VISUALIZER THREAD for 3D OBJECT DISPLAY
+ * Copyright (C) 2015 iCub Facility - Istituto Italiano di Tecnologia
+ * Author: Tanis Mar
+ * email: tanis.mar@iit.it
+ * Permission is granted to copy, distribute, and/or modify this program
+ * under the terms of the GNU General Public License, version 2 or any
+ * later version published by the Free Software Foundation.
+ *
+ * A copy of the license can be found at
+ * http://www.robotcub.org/icub/license/gpl.txt
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details
+*/
+
+#ifndef __PCLVISTHRD_H__
+#define __PCLVISTHRD_H__
+
+// Includes
+
+#include <iostream>
+#include <string>
+
+#include <yarp/os/RateThread.h>
+#include <yarp/os/Network.h>
+
+#include <pcl/io/io.h>
+#include <pcl/io/ply_io.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/point_types.h>
+#include <pcl/visualization/pcl_visualizer.h>
+#include <pcl/features/normal_3d.h>
+#include <pcl/features/moment_of_inertia_estimation.h>
+
+
+class VisThread: public yarp::os::RateThread
+{
+protected:
+    // EXTERNAL VARIABLES: set on call
+    std::string id;
+
+    // INTERNAL VARIABLES:
+    // Mutex cotnrol
+    bool update;
+    boost::mutex updateModelMutex;
+
+    // Visualizer global variables
+    pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud;
+	boost::shared_ptr<pcl::visualization::PCLVisualizer> viewer;
+
+    // Flow control flags
+    bool initialized;
+    bool addClouds;
+    bool clearing;
+    bool updatingCloud;
+    bool displayNormals;
+    bool displayBB;
+
+    // Processing parameters
+    bool minimumBB;
+    double radiusSearch;
+
+    /**
+     * @brief updateVis -  Unlocks the mutex on a cycle so that the visualizer and its contents can be updated
+     */
+    void updateVis();
+
+    /**
+     * @brief plotBB - Computes and displays Bounding Box
+     * @param minBB - true for oriented (minimum) boinding box. False for axis aligned bounding box
+     */
+    void plotBB(bool minBB);            // Function called within the update loop.
+
+    /**
+     * @brief plotNormals - Computes and displays Normals
+     * @param rS - radiusSearch for consider nerighbors to compute surface normal.
+     */
+    void plotNormals(double rS);        // Function called within the update loop.
+
+public:
+    // CONSTRUCTOR
+    VisThread(int period, const std::string &_cloudname);
+    // INIT
+    virtual bool threadInit();
+    // RUN
+    virtual void run();
+    // RELEASE
+    virtual void threadRelease();
+
+    /**
+     * @brief addNormals - Sets flow to allow bounding box to be computed and added on display update.
+     * @param rS - radiusSearch for consider nerighbors to compute surface normal.
+     */
+    void addNormals(double rS);         // Function called from main module to set parameters and unlock update
+
+    /**
+     * @brief addBoundingBox
+     * @param minBB - true for oriented (minimum) boinding box. False for axis aligned bounding box
+     */
+    void addBoundingBox(bool minBB);    // Function called from main module to set parameters and unlock update
+
+    /**
+     * @brief clearVisualizer - Clears all the figures (except the coordinate system) from the display.
+     */
+    void clearVisualizer();
+
+    /**
+     * @brief updateCloud - Updates the displayed cloud with the received one.
+     * @param cloud_in - Input cloud to be displayed
+     */
+    void updateCloud(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud_in);
+
+    /**
+     * @brief accumulateClouds - Selects between displaying clouds together or not
+     * @param accum - True to accumulate clouds on display. False to display them independently
+     */
+    void accumulateClouds(bool accum);
+
+
+};
+
+#endif
+
+

--- a/object-reconstruction/object-reconstruction.xml
+++ b/object-reconstruction/object-reconstruction.xml
@@ -1,0 +1,72 @@
+<module>
+    <!-- module's name should match its executable file's name. -->
+    <name>object-reconstruction</name>
+    <description> A module to reconstruct in 3D a set of pixel and visualize the reconstruction.</description>
+    <version>1.0</version>
+
+    <!-- <arguments> can have multiple <param> tags-->
+    <arguments>
+        <param desc="Name of the module" default="object-reconstruction"> name</param>
+	    <param desc="Robot" default="icub"> robot</param>
+        <param desc="Sub-path from \c $ICUB_ROOT/app to the configuration file" default="object-reconstruction"> context </param>
+    </arguments>
+
+    <!-- <authors> can have multiple <author> tags. -->
+    <authors>
+	  <author email="ilaria.gori@iit.it"> Ilaria Gori</author>
+	  <author email="tanis.mar@iit.it"> Tanis Mar</author>
+    </authors>
+
+     <!-- <data> can have multiple <input> or <output> tags. -->
+     <data>
+        <!-- input data if available -->
+        <input>
+            <type>ImageOfPixelRgb</type>
+            <port carrier="udp">/object-reconstruction/left:i</port>
+            <required>yes</required>
+            <priority>no</priority>
+            <description> Receives incoming images from the left eye. </description>
+        </input>
+        <input>
+            <type>ImageOfPixelRgb</type>
+            <port carrier="udp">/object-reconstruction/right:i</port>
+            <required>yes</required>
+            <priority>no</priority>
+            <description> Receives incoming images from the right eye. </description>
+        </input>
+        <input port_type="service">
+            <type>rpc</type>
+            <port carrier="tcp">/object-reconstruction/rpc</port>
+            <description> Takes RPC commands</description>
+        </input>
+        <!-- output data if available -->        
+        <output>
+            <type>Bottle</type>
+            <port>/object-reconstruction/mesh:o</port>
+            <description> Sends out the 3D reconstruction as a 'mesh' defined as SurfaceMesh(withBoundingBox) from objects3D library.</description>
+        </output>
+        <output port_type="service">
+            <type>rpc</type>
+            <port>/object-reconstruction/segmentation</port>
+            <description> Sends out the seed to the segmentation module, and receives the list of pixels belonging to the segmented object blob.</description>
+        </output>
+    </data>
+
+    <dependencies>
+        <computer>
+        </computer>
+    </dependencies>
+
+    <!-- specific libraries or header files which are used for development -->
+    <development>
+        <header></header>
+        <library>YARP</library>
+        <library>objects3D</library>
+        <library>minimumBoundingBox</library>
+        <library>stereoVision</library>
+        <library>OpenCV</library>
+        <library>Point Cloud Library.</library>
+    </development>
+
+</module>
+

--- a/object-reconstruction/src/objectReconstr.cpp
+++ b/object-reconstruction/src/objectReconstr.cpp
@@ -34,7 +34,7 @@ ObjectReconstr::ObjectReconstr()
 bool ObjectReconstr::configure(ResourceFinder &rf)
 {
     string robot=rf.check("robot",Value("icub")).asString().c_str();
-    string name=rf.check("name",Value("objectReconstr")).asString().c_str();
+    string name=rf.check("name",Value("object-reconstruction")).asString().c_str();
     setName(name.c_str());
     outputDir=rf.getHomeContextPath().c_str();
     string boundBox=rf.check("computeBB",Value("on")).asString().c_str();
@@ -71,8 +71,8 @@ bool ObjectReconstr::configure(ResourceFinder &rf)
         imagePortInRight.close();
         return false;
     }
-
     segmentationPort.open((slash+getName().c_str()+"/segmentation").c_str());
+
     pointCloudPort.open((slash + getName().c_str() + "/mesh:o").c_str());
     rpc.open((slash + getName().c_str() + "/rpc").c_str());
     attach(rpc);
@@ -89,6 +89,17 @@ bool ObjectReconstr::configure(ResourceFinder &rf)
         return false;
     }
 
+    // Visualizer Thread
+    visThrd = new VisThread(50, "Cloud");
+    if (!visThrd->start())
+    {
+        delete visThrd;
+        visThrd = 0;
+        cout << "\nERROR!!! visThread wasn't instantiated!!\n";
+        return false;
+    }
+    cout << "PCL visualizer Thread istantiated...\n";
+
     return true;
 }
 
@@ -103,6 +114,12 @@ bool ObjectReconstr::close()
     segmentationPort.close();
 
     recRoutine.close();
+    if (visThrd)    //Close visualization thread clean.
+    {
+        visThrd->stop();
+        delete visThrd;
+        visThrd =  0;
+    }
 
     return true;
 }
@@ -248,6 +265,7 @@ bool ObjectReconstr::updateModule()
             pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud=recRoutine.getPointCloud();
             if (visualizationOn)
             {
+                /*
                 boost::shared_ptr<pcl::visualization::PCLVisualizer> tmpViewer(new pcl::visualization::PCLVisualizer("Point Cloud Viewer"));
                 tmpViewer->setBackgroundColor (0, 0, 0);
                 if (computeBB)
@@ -257,6 +275,15 @@ bool ObjectReconstr::updateModule()
                 pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloudComplete;
                 cloudComplete=recRoutine.getPointCloudComplete();
                 visualize(tmpViewer, cloudComplete);
+                */
+
+                visThrd->updateCloud(cloud);
+                if (computeBB)
+                {
+                    visThrd->addBoundingBox(true);
+                }
+
+
             }
             currentState=STATE_WAIT;
         }
@@ -451,6 +478,7 @@ bool ObjectReconstr::respond(const Bottle& command, Bottle& reply)
 }
 
 /************************************************************************/
+/*
 void ObjectReconstr::visualize(boost::shared_ptr<pcl::visualization::PCLVisualizer> tmpViewer, pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr cloud)
 {
     pcl::visualization::PointCloudColorHandlerRGBField<pcl::PointXYZRGB> rgb(cloud);
@@ -472,3 +500,4 @@ void ObjectReconstr::visualize(boost::shared_ptr<pcl::visualization::PCLVisualiz
     tmpViewer->removePointCloud(id);
 }
 
+*/

--- a/object-reconstruction/src/objectReconstr.cpp
+++ b/object-reconstruction/src/objectReconstr.cpp
@@ -37,8 +37,7 @@ bool ObjectReconstr::configure(ResourceFinder &rf)
     string name=rf.check("name",Value("object-reconstruction")).asString().c_str();
     setName(name.c_str());
     outputDir=rf.getHomeContextPath().c_str();
-    string boundBox=rf.check("computeBB",Value("on")).asString().c_str();
-    computeBB=boundBox=="on";
+    computeBB=rf.check("computeBB",Value(false)).asBool();
 
     middlex=-1;
     middley=-1;
@@ -241,6 +240,7 @@ bool ObjectReconstr::updateModule()
             }
             if (computeBB)
             {
+                cout << " computing BB " << endl;
                 boundingBox=MinimumBoundingBox::getMinimumBoundingBox(cloud);
                 pointCloudOnPort.boundingBox=boundingBox.getBoundingBox();
             }
@@ -276,14 +276,12 @@ bool ObjectReconstr::updateModule()
                 cloudComplete=recRoutine.getPointCloudComplete();
                 visualize(tmpViewer, cloudComplete);
                 */
-
                 visThrd->updateCloud(cloud);
                 if (computeBB)
                 {
+                    cout << "Plotting BB " << endl;
                     visThrd->addBoundingBox(true);
                 }
-
-
             }
             currentState=STATE_WAIT;
         }

--- a/object-reconstruction/src/visThread.cpp
+++ b/object-reconstruction/src/visThread.cpp
@@ -1,0 +1,253 @@
+#include "visThread.h"
+
+using namespace std;
+using namespace yarp::os;
+
+// Empty constructor
+VisThread::VisThread(int period, const string &_cloudname):RateThread(period), id(_cloudname){}
+
+// Initialize Variables
+bool VisThread::threadInit()
+{
+    cloud = pcl::PointCloud<pcl::PointXYZRGB>::Ptr (new pcl::PointCloud<pcl::PointXYZRGB>); // Point cloud
+    viewer = boost::shared_ptr<pcl::visualization::PCLVisualizer> (new pcl::visualization::PCLVisualizer("Point Cloud Viewer")); //viewer
+    
+    //initialize here variables
+    printf("\nStarting visualizer Thread\n");
+
+    // Flags
+    initialized = false;
+    addClouds = false;
+    clearing = false;
+    updatingCloud = false;
+    displayBB = false;
+    displayNormals = false;
+
+    // Processing parameters
+    minimumBB = false;
+    radiusSearch = 0.03;
+
+    return true;
+}
+
+// Module and visualization loop
+void VisThread::run()
+{
+    if (initialized)
+    {
+        if (!viewer->wasStopped ())
+        {
+            viewer->spinOnce ();
+            // Get lock on the boolean update and check if cloud was updated
+            boost::mutex::scoped_lock updateLock(updateModelMutex);
+            if(update)
+            {
+                if(updatingCloud){
+                    // Clean visualizer to plot new cloud
+                    viewer->removePointCloud(id);
+                    viewer->removePointCloud("normals");
+                    viewer->removeAllShapes();
+
+                    // Check if the loaded file contains color information or not
+                    bool colorCloud = false;
+                    for  (int p = 1; p < cloud->points.size(); ++p)      {
+                        uint32_t rgb = *reinterpret_cast<int*>(&cloud->points[p].rgb);
+                        if (rgb != 0)
+                            colorCloud = true;
+                    }
+                    // Add cloud color if it has not
+                    if (!colorCloud)    {
+                        // Define R,G,B colors for the point cloud
+                        pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZRGB> cloud_color_handler(cloud, 230, 20, 0); //red
+                        viewer->addPointCloud (cloud, cloud_color_handler, id);
+                    }else{
+                        pcl::visualization::PointCloudColorHandlerRGBField<pcl::PointXYZRGB> cloud_color_handler (cloud);
+                        viewer->addPointCloud (cloud, cloud_color_handler, id);
+                    }
+                    viewer->setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 2, id);
+                    updatingCloud = false;
+                }
+
+                // Compute and bounding box to display
+                if (displayBB)
+                {
+                    plotBB(minimumBB);
+                    displayBB = false;
+                }
+
+                // Compute and add normals to display
+                if (displayNormals)
+                {
+                    plotNormals(radiusSearch);
+                    displayNormals = false;
+                }
+
+                // Clear display
+                if (clearing){
+                    viewer->removePointCloud(id);
+                    viewer->removePointCloud("normals");
+                    viewer->removeAllShapes();
+                    clearing = false;
+                }
+
+                update = false;
+            }
+            updateLock.unlock();
+        }else{
+            //Close viewer
+            printf("Closing Visualizer\n");
+            viewer->close();
+            viewer->removePointCloud(id);
+            this->stop();
+        }
+
+    }
+}
+
+void VisThread::threadRelease()
+{
+    printf("Closing Visualizer Thread\n");
+}
+
+// Unlock mutex temporarily to allow an update cycle on the visualizer
+void VisThread::updateVis()
+{
+    // Lock mutex while update is on
+    boost::mutex::scoped_lock updateLock(updateModelMutex);
+    update = true;
+    updateLock.unlock();
+
+    printf("Visualizer updated\n");
+}
+
+// Clear display
+void VisThread::clearVisualizer()
+{
+    clearing = true;
+    updateVis();
+}
+
+// Display new cloud received
+void VisThread::updateCloud(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud_in)
+{
+    printf("Updating displayed cloud\n");
+    if (addClouds)
+        *cloud += *cloud_in; // new cloud is added to last one
+    else
+        *cloud = *cloud_in;  // new cloud overwrites last one
+
+    if (!initialized)
+    {
+        // Set camera position and orientation
+        viewer->setBackgroundColor (0.05, 0.05, 0.05, 0); // Setting background to a dark grey
+        viewer->addCoordinateSystem (0.05);
+        initialized = true;
+    }
+
+    updatingCloud = true;
+    updateVis();
+    printf("Cloud updated\n");
+}
+
+// Set flow to allow normals to be computed and added on display update.
+void VisThread::addNormals(double rS)
+{
+    if (initialized){
+        displayNormals = true;
+        radiusSearch = rS;
+        updateVis();
+    }else{
+        printf("Please load a cloud before trying to compute the normals\n");
+    }
+}
+
+// Compute and display normals
+void VisThread::plotNormals(double rS)
+{
+    // Create the normal estimation class, and pass the input dataset to it
+    pcl::NormalEstimation<pcl::PointXYZRGB, pcl::Normal> ne;
+    ne.setInputCloud (cloud);
+
+    // Create an empty kdtree representation, and pass it to the normal estimation object.
+    // Its content will be filled inside the object, based on the given input dataset (as no other search surface is given).
+    pcl::search::KdTree<pcl::PointXYZRGB>::Ptr tree (new pcl::search::KdTree<pcl::PointXYZRGB> ());
+    ne.setSearchMethod (tree);
+
+    // Output datasets
+    pcl::PointCloud<pcl::Normal>::Ptr cloud_normals (new pcl::PointCloud<pcl::Normal>);
+
+    // Use all neighbors in a sphere of radius radiusSearch
+    ne.setRadiusSearch (rS);
+
+    // Compute the features
+    ne.compute (*cloud_normals);
+
+    viewer->addPointCloudNormals<pcl::PointXYZRGB, pcl::Normal> (cloud, cloud_normals, 30, rS, "normals");
+}
+
+// Set flow to allow bounding box to be computed and added on display update.
+void VisThread::addBoundingBox(bool minBB)
+{
+    if (initialized){
+        displayBB = true;
+        minimumBB = minBB;
+
+        updateVis();
+
+        if (minBB)
+            printf("Minimal Bounding Box added to display\n");
+        else
+            printf("Axis Aligned Bounding Box added to display\n");
+    }else{
+        printf("Please load cloud to compute Bounding box from.\n");
+    }
+}
+
+// Computes and display Bounding Box
+void VisThread::plotBB(bool minBB)
+{
+    // Create the feature extractor estimation class, and pass the input cloud to it
+    pcl::MomentOfInertiaEstimation <pcl::PointXYZRGB> feature_extractor;
+    feature_extractor.setInputCloud (cloud);
+    feature_extractor.compute ();
+
+    if (minBB)          // Oriented bounding box (OBB)
+    {   // Declare points and rotational matrix
+        pcl::PointXYZRGB min_point_OBB;
+        pcl::PointXYZRGB max_point_OBB;
+        pcl::PointXYZRGB position_OBB;
+        Eigen::Matrix3f rotational_matrix_OBB;
+
+        // Compute extrema of minimum bounding box and rotational matrix wrt axis.
+        feature_extractor.getOBB (min_point_OBB, max_point_OBB, position_OBB, rotational_matrix_OBB);
+        Eigen::Vector3f position (position_OBB.x, position_OBB.y, position_OBB.z);
+        Eigen::Quaternionf quat (rotational_matrix_OBB);
+
+        // Display oriented minimum boinding box
+        viewer->addCube (position, quat, max_point_OBB.x - min_point_OBB.x, max_point_OBB.y - min_point_OBB.y, max_point_OBB.z - min_point_OBB.z, "OBB");
+
+    }else{              // Axis-aligned bounding box (AABB)
+        // Declare extrema points of AABB
+        pcl::PointXYZRGB min_point_AABB;
+        pcl::PointXYZRGB max_point_AABB;
+
+        // Compute extrema of AABB
+        feature_extractor.getAABB (min_point_AABB, max_point_AABB);
+
+        // Display axis aligned minimum boinding box
+        viewer->addCube (min_point_AABB.x, max_point_AABB.x, min_point_AABB.y, max_point_AABB.y, min_point_AABB.z, max_point_AABB.z, 1.0, 1.0, 0.0, "AABB");
+    }
+}
+
+// Selects between displaying each cloud individually or accumulating them on the display.
+void VisThread::accumulateClouds(bool accum)
+{
+    if (accum){
+        addClouds = true;
+        printf("Clouds plotted together now\n");
+    }else{
+        addClouds = false;
+        printf("Clouds plotted separately now\n");
+    }
+}
+


### PR DESCRIPTION
Modified the code by launching the cloud visualizer in a thread, which allows viewing different clouds without having to close the visualizer as in the existing code. Moreover, the thread has functions to compute and display on the fly normals, as well as oriented and axis-aligned bounding boxes, although no rpc commands to activate them have been implemented now. Also, an existing name conflict has been resolved, now `object-reconstruction` being the default name in all initializations. 